### PR TITLE
Switch to genuine SageMath grammar

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -6,6 +6,6 @@ authors = ["Mathias Hall-Andersen <mathias@hall-andersen.dk>"]
 description = "SageMath Support for Zed"
 repository = "https://github.com/rot256/sagemath-zed"
 
-[grammars.python]
-repository = "https://github.com/tree-sitter/tree-sitter-python"
-commit = "8c65e256f971812276ff2a69a2f515c218ed7f82"
+[grammars.sage]
+repository = "https://github.com/havarddj/tree-sitter-sage.git"
+commit = "de002c5abf9e14bf92a643b4af9057d0ceb612a5"

--- a/languages/sage/config.toml
+++ b/languages/sage/config.toml
@@ -1,5 +1,5 @@
 name = "SageMath"
-grammar = "python"
+grammar = "sage"
 path_suffixes = ["sage"]
 line_comments = ["# "]
 block_comments = [["\"\"\"", "\"\"\""], ["'''", "'''"]]

--- a/languages/sage/highlights.scm
+++ b/languages/sage/highlights.scm
@@ -444,3 +444,17 @@
     (string
       (string_content) @string.regexp))
   (#eq? @_re "re"))
+
+; SageMath specific syntax:
+
+(sage_gen_assignment
+  ".<" @punctuation.bracket
+  ">" @punctuation.bracket)
+(sage_gen_assignment
+  "," @punctuation.delimiter)
+(sage_ellipsis_expr
+  ".." @punctuation.delimiter)
+(sage_ellipsis_expr
+  ",.." @punctuation.delimiter)
+(sage_ellipsis_expr
+  ",..," @punctuation.delimiter)


### PR DESCRIPTION
This PR makes use of a recently-made [SageMath grammar](https://github.com/havarddj/tree-sitter-sage/tree/main).
It's a mostly complete grammar with minor limitations mentioned [here](https://github.com/sagemath/sage/issues/30760#issuecomment-2508705467).

Here is a comparison of changes with two SageMath specific pieces of syntax (generator assignment and ellipses).

**Current highlights:**

![image](https://github.com/user-attachments/assets/2d7f837e-78a0-4453-a282-c844ab544a5a)


**Highlights with this PR:**

![image](https://github.com/user-attachments/assets/2b70c0e2-1e17-46f6-95b7-e944f5c4e691)

**Note:** the first screenshot may look like it is a better highlight for the `r` "raw" suffix on the numeric literal on line 3 (to signify python literal instead of sage), but this is just an accident with the parser assumes `r` is an identifier while recovering from a parsing error:
![image](https://github.com/user-attachments/assets/c0150d0e-1e9d-47e5-93d6-439d8b678994)
