### PR TITLE
Correct url for the extension repo

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 schema_version = 1
 authors = ["Mathias Hall-Andersen <mathias@hall-andersen.dk>"]
 description = "SageMath Support for Zed"
-repository = "https://github.com/rot256/sagemath-zed"
+repository = "https://github.com/rot256/zed-sagemath"
 
 [grammars.python]
 repository = "https://github.com/tree-sitter/tree-sitter-python"


### PR DESCRIPTION
There was a typo in the url for the repository.

Currently the "visit the repository" button on both https://zed.dev/extensions?query=sagemath and the extension window in Zed are just broken links.