### PR TITLE
Fix usages of neovim specific query directives

### DIFF
--- a/languages/sage/highlights.scm
+++ b/languages/sage/highlights.scm
@@ -9,13 +9,13 @@
 
 ; Identifier naming conventions
 ((identifier) @type
-  (#lua-match? @type "^[A-Z].*[a-z]"))
+  (#match? @type "^[A-Z].*[a-z]"))
 
 ((identifier) @constant
-  (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
+  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 ((identifier) @constant.builtin
-  (#lua-match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+  (#match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
 
 ((identifier) @constant.builtin
   (#any-of? @constant.builtin
@@ -26,7 +26,7 @@
 
 ((attribute
   attribute: (identifier) @variable.member)
-  (#lua-match? @variable.member "^[%l_].*$"))
+  (#match? @variable.member "^[%l_].*$"))
 
 ((assignment
   left: (identifier) @type.definition
@@ -50,12 +50,12 @@
 
 ((call
   function: (identifier) @constructor)
-  (#lua-match? @constructor "^%u"))
+  (#match? @constructor "^%u"))
 
 ((call
   function: (attribute
     attribute: (identifier) @constructor))
-  (#lua-match? @constructor "^%u"))
+  (#match? @constructor "^%u"))
 
 ; Decorators
 ((decorator
@@ -194,7 +194,7 @@
 ((module
   .
   (comment) @keyword.directive @nospell)
-  (#lua-match? @keyword.directive "^#!/"))
+  (#match? @keyword.directive "^#!/"))
 
 (string) @string
 
@@ -399,7 +399,7 @@
     (expression_statement
       (assignment
         left: (identifier) @variable.member))))
-  (#lua-match? @variable.member "^[%l_].*$"))
+  (#match? @variable.member "^[%l_].*$"))
 
 ((class_definition
   body: (block
@@ -407,7 +407,7 @@
       (assignment
         left: (_
           (identifier) @variable.member)))))
-  (#lua-match? @variable.member "^[%l_].*$"))
+  (#match? @variable.member "^[%l_].*$"))
 
 ((class_definition
   (block


### PR DESCRIPTION
`lua-match` has no effect in Zed, this PR fixes these.

This reveals some extra highlights, for example the following (highlights on identifiers based on naming conventions) are all currently highlighted the same:

![image](https://github.com/user-attachments/assets/3cd93a81-53db-4095-8506-f3c1f1008706)
